### PR TITLE
Make inputPath a required parameter

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,19 +1,9 @@
 {
     "version": "0.2.0",
     "configurations": [
+
         {
-            "name": "Launch RVToolsMerge (Default)",
-            "type": "coreclr",
-            "request": "launch",
-            "preLaunchTask": "build",
-            "program": "${workspaceFolder}/bin/Debug/net9.0/win-x64/RVToolsMerge.exe",
-            "args": [],
-            "cwd": "${workspaceFolder}",
-            "console": "internalConsole",
-            "stopAtEntry": false
-        },
-        {
-            "name": "Launch with Folder Input",
+            "name": "Launch with Folder Input (Default)",
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",

--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -1,79 +1,40 @@
 {
   "profiles": {
-    "RVToolsMerge": {
+    "RVToolsMerge (Default)": {
       "commandName": "Project",
-      "commandLineArgs": "\"input\" \"RVTools_merged.xlsx\"",
-      "workingDirectory": "$(ProjectDir)"
+      "commandLineArgs": "$(ProjectDir)\\input"
     },
-    "RVToolsMerge (Ignore Missing Optional Sheets)": {
+    "RVToolsMerge (Ignore Missing Sheets)": {
       "commandName": "Project",
-      "commandLineArgs": "--ignore-missing-optional-sheets \"input\" \"RVTools_merged.xlsx\"",
-      "workingDirectory": "$(ProjectDir)"
+      "commandLineArgs": "-m $(ProjectDir)\\input"
     },
     "RVToolsMerge (Skip Invalid Files)": {
       "commandName": "Project",
-      "commandLineArgs": "--skip-invalid-files \"input\" \"RVTools_merged.xlsx\"",
-      "workingDirectory": "$(ProjectDir)"
+      "commandLineArgs": "-i $(ProjectDir)\\input"
     },
-    "RVToolsMerge (Anonymize All)": {
+    "RVToolsMerge (Anonymize)": {
       "commandName": "Project",
-      "commandLineArgs": "-a \"input\" \"RVTools_anonymized.xlsx\"",
-      "workingDirectory": "$(ProjectDir)"
+      "commandLineArgs": "-a $(ProjectDir)\\input"
     },
-    "RVToolsMerge (Only Mandatory Columns)": {
+    "RVToolsMerge (Mandatory Columns Only)": {
       "commandName": "Project",
-      "commandLineArgs": "-o \"input\" \"RVTools_mandatory.xlsx\"",
-      "workingDirectory": "$(ProjectDir)"
+      "commandLineArgs": "-M $(ProjectDir)\\input"
     },
-    "RVToolsMerge (Anonymize & Mandatory Columns)": {
+    "RVToolsMerge (Include Source)": {
       "commandName": "Project",
-      "commandLineArgs": "-a -o \"input\" \"RVTools_anonymized_mandatory.xlsx\"",
-      "workingDirectory": "$(ProjectDir)"
+      "commandLineArgs": "-s $(ProjectDir)\\input"
     },
-    "Basic (No Options)": {
+    "RVToolsMerge (Debug Mode)": {
       "commandName": "Project",
-      "commandLineArgs": "\"$(ProjectDir)test/input/valid_complete\" \"$(ProjectDir)test/output/basic_test.xlsx\"",
-      "workingDirectory": "$(ProjectDir)"
+      "commandLineArgs": "-d $(ProjectDir)\\input"
     },
-    "Skip Invalid Files (-i)": {
+    "RVToolsMerge (Most Permissive)": {
       "commandName": "Project",
-      "commandLineArgs": "-i \"$(ProjectDir)test/input\" \"$(ProjectDir)test/output/skip_invalid.xlsx\"",
-      "workingDirectory": "$(ProjectDir)"
+      "commandLineArgs": "-s -i -m $(ProjectDir)\\input $(ProjectDir)\\output\\MostPermissive.xlsx"
     },
-    "Ignore Missing Sheets (-m)": {
+    "RVToolsMerge (Help)": {
       "commandName": "Project",
-      "commandLineArgs": "-m \"$(ProjectDir)test/input/valid_missing_optional\" \"$(ProjectDir)test/output/ignore_missing.xlsx\"",
-      "workingDirectory": "$(ProjectDir)"
-    },
-    "Most Permissive (-i -m)": {
-      "commandName": "Project",
-      "commandLineArgs": "-i -m \"$(ProjectDir)test/input\" \"$(ProjectDir)test/output/permissive_mode.xlsx\"",
-      "workingDirectory": "$(ProjectDir)"
-    },
-    "Anonymize Data (-a)": {
-      "commandName": "Project",
-      "commandLineArgs": "-a \"$(ProjectDir)test/input/valid_complete\" \"$(ProjectDir)test/output/anonymized.xlsx\"",
-      "workingDirectory": "$(ProjectDir)"
-    },
-    "Include Source Files (-s)": {
-      "commandName": "Project",
-      "commandLineArgs": "-s \"$(ProjectDir)test/input/valid_complete\" \"$(ProjectDir)test/output/with_source_files.xlsx\"",
-      "workingDirectory": "$(ProjectDir)"
-    },
-    "Mandatory Columns Only (-M)": {
-      "commandName": "Project",
-      "commandLineArgs": "-M \"$(ProjectDir)test/input/valid_complete\" \"$(ProjectDir)test/output/mandatory_only.xlsx\"",
-      "workingDirectory": "$(ProjectDir)"
-    },
-    "All Features (-i -m -a -s -M)": {
-      "commandName": "Project",
-      "commandLineArgs": "-i -m -a -s -M \"$(ProjectDir)test/input\" \"$(ProjectDir)test/output/all_features.xlsx\"",
-      "workingDirectory": "$(ProjectDir)"
-    },
-    "Debug Mode (-d -i -m)": {
-      "commandName": "Project",
-      "commandLineArgs": "-d -i -m \"$(ProjectDir)test/input\" \"$(ProjectDir)test/output/debug_mode.xlsx\"",
-      "workingDirectory": "$(ProjectDir)"
+      "commandLineArgs": "--help"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -111,22 +111,22 @@ Download the latest release for your platform from the [Releases page](https://g
 ## Usage
 
 ```
-RVToolsMerge [options] [inputPath] [outputFile]
+RVToolsMerge [options] inputPath [outputFile]
 ```
 
 ### Arguments
 
 | Argument | Description | Default |
 |----------|-------------|---------|
-| `inputPath` | Path to an Excel file or folder containing RVTools exports | `./input` subfolder |
-| `outputFile` | Path where the merged file will be saved | `./RVTools_Merged.xlsx` |
+| `inputPath` | Path to an Excel file or folder containing RVTools exports | **Required** |
+| `outputFile` | Path where the merged file will be saved | `./RVTools_Merged.xlsx` in current directory |
 
 ### Options
 
 | Option | Description |
 |--------|-------------|
 | `-h, --help, /?` | Show the help message and exit |
-| `-m, --ignore-missing-optional-sheets` | Process files even when optional sheets are missing |
+| `-m, --ignore-missing-sheets` | Process files even when optional sheets are missing |
 | `-i, --skip-invalid-files` | Skip files that don't meet validation requirements |
 | `-a, --anonymize` | Anonymize VM, DNS, Cluster, Host, and Datacenter names |
 | `-M, --only-mandatory-columns` | Include only mandatory columns in the output |
@@ -140,7 +140,7 @@ RVToolsMerge [options] [inputPath] [outputFile]
 ### Basic Usage
 
 ```cmd
-:: Process all Excel files in a folder 
+:: Process all Excel files in a folder (required parameter)
 RVToolsMerge.exe C:\RVTools\Exports
 
 :: Process a single file
@@ -182,7 +182,7 @@ RVToolsMerge implements robust validation to ensure data integrity:
 ### Validation Rules
 
 - **By default**: All required sheets with all mandatory columns must exist in all files
-- **With `-m` (ignore-missing-optional-sheets)**: 
+- **With `-m` (ignore-missing-sheets)**: 
   - The vInfo sheet remains required in all files
   - Optional sheets (vHost, vPartition, vMemory) can be missing
   - Missing mandatory columns in optional sheets will cause errors unless handled by other options

--- a/RVToolsMerge.csproj
+++ b/RVToolsMerge.csproj
@@ -9,7 +9,6 @@
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PublishReadyToRun>true</PublishReadyToRun>
     <PublishTrimmed>true</PublishTrimmed>
-    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
     <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
     <SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
     <DebugType>embedded</DebugType>


### PR DESCRIPTION
Update the command-line interface to require the inputPath parameter, ensuring users provide a valid path for processing. Adjust documentation and launch configurations accordingly.