### PR TITLE
Potential fix for code scanning alert no. 17: Useless assignment to local variable

### DIFF
--- a/src/RVToolsMerge/ApplicationRunner.cs
+++ b/src/RVToolsMerge/ApplicationRunner.cs
@@ -142,7 +142,6 @@ public class ApplicationRunner
         try
         {
             var fullPath = _fileSystem.Path.GetFullPath(path);
-            var currentDir = _fileSystem.Directory.GetCurrentDirectory();
             
             // For input files, we allow any valid path as long as it's not traversal
             // For output files, this validation should be called separately


### PR DESCRIPTION
Potential fix for [https://github.com/sbroenne/RvToolsMerge/security/code-scanning/17](https://github.com/sbroenne/RvToolsMerge/security/code-scanning/17)

To fix the issue, the assignment to `currentDir` on line 145 should be removed entirely, as it serves no purpose in the current implementation. This will eliminate the redundant code and improve clarity. No additional changes are required since the removal does not affect the logic of the method.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
