### PR TITLE
Move WiX Toolset installation to MSI creation step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,15 +105,6 @@ jobs:
         if: runner.os != 'Windows'
         run: chmod +x publish/RVToolsMerge
 
-      - name: Install WiX Toolset (Windows only)
-        if: runner.os == 'Windows' && inputs.configuration == 'Release'
-        run: |
-          # Install WiX toolset
-          dotnet tool install --global wix
-          # Add WiX UI extension
-          wix extension add -g WixToolset.UI.wixext
-        shell: pwsh
-
       - name: Create MSI installer (Windows only)
         if: runner.os == 'Windows' && inputs.configuration == 'Release'
         working-directory: installer
@@ -149,6 +140,11 @@ jobs:
               Write-Error "Invalid version format: $version. Expected format: X.Y.Z or X.Y.Z.W"
               exit 1
           }
+
+          # Install WiX toolset
+          dotnet tool install --global wix
+          # Add WiX UI extension
+          wix extension add WixToolset.UI.wixext
 
           # Build MSI using wix command
           $msiName = "RVToolsMerge-$version-${{ matrix.runtime }}.msi"

--- a/installer/README.md
+++ b/installer/README.md
@@ -41,7 +41,7 @@ To build MSI installers locally (Windows only):
 # Install WiX Toolset 6.0.1
 dotnet tool install --global wix --version 6.0.1
 # Add WiX UI extension
-wix extension add -g WixToolset.UI.wixext
+wix extension add WixToolset.UI.wixext
 ```
 
 ### Build Steps

--- a/installer/RVToolsMerge.Installer.wixproj
+++ b/installer/RVToolsMerge.Installer.wixproj
@@ -14,9 +14,4 @@
     <Compile Include="RVToolsMerge.wxs" />
   </ItemGroup>
 
-<ItemGroup>
-  <PackageReference Include="WixToolset.UI.wixext" />
-</ItemGroup>
-
-
 </Project>


### PR DESCRIPTION
Relocate the installation of the WiX Toolset to the MSI creation step and remove the package reference from the project file. This change streamlines the build process for MSI installers.