### PR TITLE
Add ProductCode extraction for x64 and ARM64 MSIs in winget manifest generation

### DIFF
--- a/.github/winget-templates/RvToolsMerge.RvToolsMerge.installer.yaml.template
+++ b/.github/winget-templates/RvToolsMerge.RvToolsMerge.installer.yaml.template
@@ -22,6 +22,7 @@ Installers:
   InstallerType: wix
   InstallerUrl: https://github.com/sbroenne/RVToolsMerge/releases/download/v{{VERSION}}/RVToolsMerge-{{VERSION}}-win-x64.msi
   InstallerSha256: {{X64_SHA256}}
+  ProductCode: {{X64_PRODUCT_CODE}}
   AppsAndFeaturesEntries:
   - DisplayName: RVToolsMerge
     Publisher: Stefan Broenner
@@ -32,6 +33,7 @@ Installers:
   InstallerType: wix
   InstallerUrl: https://github.com/sbroenne/RVToolsMerge/releases/download/v{{VERSION}}/RVToolsMerge-{{VERSION}}-win-arm64.msi
   InstallerSha256: {{ARM64_SHA256}}
+  ProductCode: {{ARM64_PRODUCT_CODE}}
   AppsAndFeaturesEntries:
   - DisplayName: RVToolsMerge
     Publisher: Stefan Broenner


### PR DESCRIPTION
Implement functionality to extract ProductCode from MSI files and include it in the generated winget manifest. This enhancement supports both x64 and ARM64 architectures.