### PR TITLE
fix: Spectre CLI ExecuteAsync access modifier

### DIFF
--- a/src/RVToolsMerge/Commands/MergeCommand.cs
+++ b/src/RVToolsMerge/Commands/MergeCommand.cs
@@ -47,7 +47,7 @@ public class MergeCommand : AsyncCommand<MergeCommandSettings>
     /// <param name="settings">The command settings.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Exit code (0 for success, 1 for error).</returns>
-    public override async Task<int> ExecuteAsync(CommandContext context, MergeCommandSettings settings, CancellationToken cancellationToken)
+    protected override async Task<int> ExecuteAsync(CommandContext context, MergeCommandSettings settings, CancellationToken cancellationToken)
     {
         // Get version and product information
         var appInfo = GetApplicationInfo();


### PR DESCRIPTION
This fixes the build break currently affecting Dependabot PRs #221, #222, and #223.\n\n is now inherited as a protected member, so the override in  must be  instead of .\n\nAfter this merges, the failing Dependabot PRs should rebase/update cleanly.